### PR TITLE
Change demo app url in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ __Web Service provided by http://viacep.com.br/__
 
 ### Demo
 
-[Demo Artesãos ZipCode](http://canducci-canducci.c9.io/zipcode)
+[Demo Artesãos ZipCode](http://zipcodeartesao.herokuapp.com/)
 
 ## Quick start
 


### PR DESCRIPTION
Changed the URL of the application demonstration due to link breaks.

[New Demo](https://dashboard.heroku.com/apps/zipcodeartesao/settings)